### PR TITLE
CASMHMS-5612 Helm CT test enhancements and CVE remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,0 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/changelog/v1.0.md
+++ b/changelog/v1.0.md
@@ -1,10 +1,18 @@
 # Changelog for v1.0
 
-All notable changes to this project for v2.0.X will be documented in this file.
+All notable changes to this project for v1.0.X will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2022-07-15
+
+### Changed
+
+- updated helm chart to appVersion 3.2.0 for hms-test image enhancements
+
 ## [1.0.0] - 2022-03-28
+
 ### Added
+
 - created initial helm chart for development environment

--- a/changelog/v1.0.md
+++ b/changelog/v1.0.md
@@ -5,11 +5,11 @@ All notable changes to this project for v1.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - 2022-07-18
+## [1.0.1] - 2022-07-19
 
 ### Changed
 
-- updated helm chart to appVersion 3.2.0 for hms-test image enhancements
+- updated helm chart to appVersion 3.2.0 for hms-test image enhancements and CVE remediation
 
 ## [1.0.0] - 2022-03-28
 

--- a/changelog/v1.0.md
+++ b/changelog/v1.0.md
@@ -5,7 +5,7 @@ All notable changes to this project for v1.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - 2022-07-15
+## [1.0.1] - 2022-07-18
 
 ### Changed
 

--- a/charts/v1.0/cray-hms-test-development/Chart.yaml
+++ b/charts/v1.0/cray-hms-test-development/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-test-development"
-version: 1.0.0
+version: 1.0.1
 description: "Kubernetes resources for cray-hms-test-development"
 home: https://github.com/Cray-HPE/hms-test-charts
 sources:
@@ -13,4 +13,4 @@ dependencies:
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT
-appVersion: 3.0.0
+appVersion: 3.2.0

--- a/charts/v1.0/cray-hms-test-development/values.yaml
+++ b/charts/v1.0/cray-hms-test-development/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 3.0.0
+  appVersion: 3.2.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-test

--- a/cray-hms-test.compatibility.yaml
+++ b/cray-hms-test.compatibility.yaml
@@ -2,30 +2,22 @@
 # CSM Version is not really following semver.
 chartVersionToCSMVersion:
   # Chart version: CSM version
-  ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  ">=1.0.0": "~1.3.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
 
 # The application version must be compliant to semantic versioning. 
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
 # This is the idealized world
 chartVersionToApplicationVersion:
   # Chart version: Application version
-  "2.0.0": "1.11.0"
-  "2.0.1": "1.12.0"
-  "2.0.2": "1.13.0"
+  "1.0.0": "3.0.0"
+  "1.0.1": "3.2.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
-chartValidationLog:
-- chartVersion: 2.0.0
-  applicationVersion: 1.11.0
-  csm: 1.2.0-alpha.16
-  environment: baremetal 
-  result: PASS 
-  tester: rsjostrand-hpe
-  date: 2021-11-17
-- chartVersion: 2.0.1-20211117222138+a343000b
-  applicationVersion: 1.12.0
-  csm: 1.2.0-alpha.16
-  environment: baremetal 
-  result: PASS 
-  tester: rsjostrand-hpe
-  date: 2021-11-17
+chartValidationLog: []
+#- chartVersion: 2.0.0
+#  applicationVersion: 1.11.0
+#  csm: 1.2.0-alpha.16
+#  environment: baremetal
+#  result: PASS
+#  tester: rsjostrand-hpe
+#  date: 2021-11-17


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes for the Helm CT tests:

- kill the istio sidecar after the tests run to save wait time
- remove build dependencies from final test image that aren't needed to run the tests
- revert back to alpine:3.15 base image to resolve CVEs

### Issues and Related PRs

* Partially resolves CASMHMS-5612.

### Testing

This change was tested by deploying a new version of CAPMC on Mug which pulled in the latest version of the hms-test image, executing its Helm CT tests, and verifying that they passed. Also verified that the test pod was no longer stuck in "NotReady" after the tests completed. Lastly, verified the change in the runCT environment and confirmed that it passed its Snyk checks that were previously failing.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, minor test changes and CVE remediation.